### PR TITLE
Small update to use Replace instead of Split

### DIFF
--- a/netsuite-rest.js
+++ b/netsuite-rest.js
@@ -51,13 +51,7 @@ class NetsuiteRest {
         if (this.realm.toLowerCase().includes("sb")) {
         // The account id is a Sandbox address - typically XXXXXX_SB or XXXXXX_SB1
         // This needs converted to a dash for the URI
-        const realmSplit = this.realm.split("_");
-
-        // Append the Sandbox Value onto the end with a dash instead
-        const realmUrl = `${realmSplit[0]}-${realmSplit[1].toLowerCase()}`;
-
-        // Setup Uri
-        uri = `https://${realmUrl}.suitetalk.api.netsuite.com/services/rest/${path}`;
+        uri = `https://${this.realm.toLowerCase().replace("_sb", "-sb")}.suitetalk.api.netsuite.com/services/rest/${path}`;
         } else {
         // Account is not a sandbox - is Production account, pass realm Directly into URI
         uri = `https://${this.realm}.suitetalk.api.netsuite.com/services/rest/${path}`;


### PR DESCRIPTION
Updated uri split functionality to just use replace instead - makes code much more tidy -  Still left in the If/Else to identify if production or Sandbox